### PR TITLE
Add PITCH mnemonic and processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,10 @@ specifications, as well as pseudo operations.
 
 ### XO Chip Mnemonics
 
-| Mnemonic | Opcode | Operands | Description                                    |
-|----------|--------|:--------:|------------------------------------------------|
-| `AUDIO`  | `F002` |    0     | Load 16-byte audio pattern buffer from `index` |
+| Mnemonic | Opcode | Operands | Description                                          |
+|----------|--------|:--------:|------------------------------------------------------|
+| `AUDIO`  | `F002` |    0     | Load 16-byte audio pattern buffer from `index`       |
+| `PITCH`  | `Fs3A` |    1     | Sets the internal pitch to the value in register `s` |
 
 
 ### Pseudo Operations

--- a/chip8asm/statement.py
+++ b/chip8asm/statement.py
@@ -51,7 +51,6 @@ OPERATIONS = [
     Operation(op="Dstn", operands=3, source=1, target=1, numeric=1, mnemonic="DRAW"),
     Operation(op="Es9E", operands=1, source=1, target=0, numeric=0, mnemonic="SKPR"),
     Operation(op="EsA1", operands=1, source=1, target=0, numeric=0, mnemonic="SKUP"),
-    Operation(op="F002", operands=0, source=0, target=0, numeric=0, mnemonic="AUDIO"),
     Operation(op="Ft07", operands=1, source=0, target=1, numeric=0, mnemonic="MOVED"),
     Operation(op="Ft0A", operands=1, source=0, target=1, numeric=0, mnemonic="KEYD"),
     Operation(op="Fs15", operands=1, source=1, target=0, numeric=0, mnemonic="LOADD"),
@@ -69,7 +68,10 @@ OPERATIONS = [
     Operation(op="00FE", operands=0, source=0, target=0, numeric=0, mnemonic="EXTD"),
     Operation(op="00FF", operands=0, source=0, target=0, numeric=0, mnemonic="EXTE"),
     Operation(op="Fs75", operands=1, source=1, target=0, numeric=0, mnemonic="SRPL"),
-    Operation(op="Fs85", operands=1, source=1, target=0, numeric=0, mnemonic="LRPL")
+    Operation(op="Fs85", operands=1, source=1, target=0, numeric=0, mnemonic="LRPL"),
+    # XO Chip Instructions
+    Operation(op="F002", operands=0, source=0, target=0, numeric=0, mnemonic="AUDIO"),
+    Operation(op="Fs3A", operands=1, source=1, target=0, numeric=0, mnemonic="PITCH"),
 ]
 
 # Pseudo operations

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -46,7 +46,7 @@ class TestIntegration(unittest.TestCase):
     def test_pitch_mnemonic_translate_correct(self):
         program = Program()
         statement = Statement()
-        statement.parse_line("    PITCH r1    ; audio statement")
+        statement.parse_line("    PITCH r1    ; pitch statement")
         program.statements.append(statement)
         program = self.translate_statements(program)
         machine_code = program.generate_machine_code()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -43,4 +43,13 @@ class TestIntegration(unittest.TestCase):
         machine_code = program.generate_machine_code()
         self.assertEqual([0xF0, 0x02], machine_code)
 
+    def test_pitch_mnemonic_translate_correct(self):
+        program = Program()
+        statement = Statement()
+        statement.parse_line("    PITCH r1    ; audio statement")
+        program.statements.append(statement)
+        program = self.translate_statements(program)
+        machine_code = program.generate_machine_code()
+        self.assertEqual([0xF1, 0x3A], machine_code)
+
 # E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR adds the `PITCH` mnemonic to the assembler. Integration tests updated to cover new instruction. This PR closes #8