### PR TITLE
Implement the PLANE mnemonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ specifications, as well as pseudo operations.
 | Mnemonic | Opcode | Operands | Description                                          |
 |----------|--------|:--------:|------------------------------------------------------|
 | `AUDIO`  | `F002` |    0     | Load 16-byte audio pattern buffer from `index`       |
+| `PLANE`  | `Fn03` |    1     | Sets the drawing bitplane to `n`                     |
 | `PITCH`  | `Fs3A` |    1     | Sets the internal pitch to the value in register `s` |
 
 

--- a/chip8asm/statement.py
+++ b/chip8asm/statement.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2014-2019 Craig Thomas
+Copyright (C) 2024 Craig Thomas
 This project uses an MIT style license - see LICENSE for details.
 
 This file contains Exceptions for the Chip 8 Assembler.
@@ -71,6 +71,7 @@ OPERATIONS = [
     Operation(op="Fs85", operands=1, source=1, target=0, numeric=0, mnemonic="LRPL"),
     # XO Chip Instructions
     Operation(op="F002", operands=0, source=0, target=0, numeric=0, mnemonic="AUDIO"),
+    Operation(op="Fn03", operands=1, source=0, target=0, numeric=1, mnemonic="PLANE"),
     Operation(op="Fs3A", operands=1, source=1, target=0, numeric=0, mnemonic="PITCH"),
 ]
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -52,4 +52,13 @@ class TestIntegration(unittest.TestCase):
         machine_code = program.generate_machine_code()
         self.assertEqual([0xF1, 0x3A], machine_code)
 
+    def test_plane_mnemonic_translate_correct(self):
+        program = Program()
+        statement = Statement()
+        statement.parse_line("    PLANE $2    ; plane statement")
+        program.statements.append(statement)
+        program = self.translate_statements(program)
+        machine_code = program.generate_machine_code()
+        self.assertEqual([0xF2, 0x03], machine_code)
+
 # E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR adds the PLANE mnemonic to the assembler. Integration tests updated to match new functionality. This PR closes #7 