### PR TITLE
Implement LOADSUB operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ specifications, as well as pseudo operations.
 
 ### XO Chip Mnemonics
 
-| Mnemonic   | Opcode | Operands | Description                                          |
-|------------|--------|:--------:|------------------------------------------------------|
-| `SAVESUB`  | `5st2` |    2     | Saves subset of registers from `s` to `t` in memory  |
-| `AUDIO`    | `F002` |    0     | Load 16-byte audio pattern buffer from `index`       |
-| `PLANE`    | `Fn03` |    1     | Sets the drawing bitplane to `n`                     |
-| `PITCH`    | `Fs3A` |    1     | Sets the internal pitch to the value in register `s` |
+| Mnemonic   | Opcode | Operands | Description                                           |
+|------------|--------|:--------:|-------------------------------------------------------|
+| `SAVESUB`  | `5st2` |    2     | Saves subset of registers from `s` to `t` in memory   |
+| `LOADSUB`  | `5st3` |    2     | Loads subset of registers from `s` to `t` from memory |
+| `AUDIO`    | `F002` |    0     | Load 16-byte audio pattern buffer from `index`        |
+| `PLANE`    | `Fn03` |    1     | Sets the drawing bitplane to `n`                      |
+| `PITCH`    | `Fs3A` |    1     | Sets the internal pitch to the value in register `s`  |
 
 
 ### Pseudo Operations

--- a/chip8asm/statement.py
+++ b/chip8asm/statement.py
@@ -71,6 +71,7 @@ OPERATIONS = [
     Operation(op="Fs85", operands=1, source=1, target=0, numeric=0, mnemonic="LRPL"),
     # XO Chip Instructions
     Operation(op="5st2", operands=2, source=1, target=1, numeric=0, mnemonic="SAVESUB"),
+    Operation(op="5st3", operands=2, source=1, target=1, numeric=0, mnemonic="LOADSUB"),
     Operation(op="F002", operands=0, source=0, target=0, numeric=0, mnemonic="AUDIO"),
     Operation(op="Fn03", operands=1, source=0, target=0, numeric=1, mnemonic="PLANE"),
     Operation(op="Fs3A", operands=1, source=1, target=0, numeric=0, mnemonic="PITCH"),

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -70,4 +70,13 @@ class TestIntegration(unittest.TestCase):
         machine_code = program.generate_machine_code()
         self.assertEqual([0x51, 0x62], machine_code)
 
+    def test_loadsub_mnemonic_translate_correct(self):
+        program = Program()
+        statement = Statement()
+        statement.parse_line("    LOADSUB r1,r6    ; load subset statement")
+        program.statements.append(statement)
+        program = self.translate_statements(program)
+        machine_code = program.generate_machine_code()
+        self.assertEqual([0x51, 0x63], machine_code)
+
 # E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR implements the `LOADSUB` operation which loads a subset of registers from memory. Integration tests updated to catch new conditions. This PR closes #11 